### PR TITLE
Support multiple edges via next()

### DIFF
--- a/flow.js
+++ b/flow.js
@@ -3,10 +3,12 @@
 var Flow = {
     Action: require('./lib/action'),
     Builder: require('./lib/builder'),
+    Edge: require('./lib/edge'),
     Graph: require('./lib/graph'),
     GraphComposer: require('./lib/graph_composer'),
     GraphValidator: require('./lib/graph_validator'),
     Traverser: require('./lib/flow'),
+    Vertex: require('./lib/vertex'),
 };
 
 module.exports = Flow;

--- a/lib/action.js
+++ b/lib/action.js
@@ -6,8 +6,7 @@ var extend = require('./extend.js');
 
 var Action = function (options) {
     assertWith(options)
-        .expectProperty('flow', 'FlowAdapter requires a flow')
-        .expectProperty('payload', 'FlowAdapter requires a payload');
+        .expectProperty('flow', 'Action requires a flow');
     this.flow = options.flow;
     this.payload = options.payload;
 };

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,13 +1,16 @@
 'use strict';
 
 var _ = require('underscore');
+var assertWith = require('./assert_with');
 var extend = require('./extend');
+var Edge = require('./edge');
 var Flow = require('./flow');
 var Graph = require('./graph');
+var Vertex = require('./vertex');
 
 var Builder = function () {
-    this.vertices = {};
-    this.edges = {};
+    this.vertices = [];
+    this.edges = [];
     this.source = undefined;
     this.graph = undefined;
     this.actionBuilderFunctions = [];
@@ -16,16 +19,32 @@ var Builder = function () {
 Builder.extend = _.partial(extend, Builder);
 
 _.extend(Builder.prototype, {
+    _buildVertexEdges: function (vertex, next) {
+        if (!next) {
+            return [];
+        }
+        if (_.isString(next)) {
+            return [
+                new Edge(vertex.getName(), next)
+            ];
+        }
+        return _.keys(next).reduce(function (previous, edgeSink) {
+            var pathChoiceFn = next[edgeSink];
+            previous.push(new Edge(vertex.getName(), edgeSink, pathChoiceFn));
+            return previous;
+        }, []);
+    },
+
     addActionBuilder: function (actionBuilderFn) {
         this.actionBuilderFunctions.push(actionBuilderFn);
         return this;
     },
 
-    addVertex: function (name, payload, next) {
-        this.vertices[name] = payload;
-        if (next) {
-            this.edges[name] = next;
-        }
+    addVertex: function (options, payload) {
+        assertWith(options).expectProperty('name', 'An added vertex requres a name');
+        var vertex = new Vertex(options.name, payload);
+        this.vertices.push(vertex);
+        this.edges = this.edges.concat(this._buildVertexEdges(vertex, options.next));
         return this;
     },
 

--- a/lib/edge.js
+++ b/lib/edge.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var _ = require('underscore');
+var extend = require('./extend');
+
+var defaultPathChoiceFn = function () {
+    return true;
+};
+
+var Edge = function (edgeSource, edgeSink, pathChoiceFn) {
+    this.edgeSource = edgeSource;
+    this.edgeSink = edgeSink;
+    this.pathChoiceFn = pathChoiceFn || defaultPathChoiceFn;
+};
+Edge.extend =  _.partial(extend, Edge);
+
+_.extend(Edge.prototype, {
+    getEdgeSink: function () {
+        return this.edgeSink;
+    },
+
+    getEdgeSource: function () {
+        return this.edgeSource;
+    },
+
+    shouldTakeEdge: function (options) {
+        return this.pathChoiceFn(options);
+    },
+});
+
+module.exports = Edge;

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -18,7 +18,7 @@ Flow.extend = _.partial(extend, Flow);
 _.extend(Flow.prototype, {
     _buildActions: function (vertex) {
         var flow = this;
-        var payload= this.getGraph().getVertexPayload(vertex);
+        var payload = vertex.getPayload();
         return this.actionBuilderFunctions.map(function (actionBuilderFn) {
             return actionBuilderFn(flow, payload);
         });
@@ -73,17 +73,17 @@ _.extend(Flow.prototype, {
         return this.whenFinishedFunctions;
     },
 
-    jumpTo: function (vertex) {
-        if (this.graph.hasVertex(vertex)) {
-            this.currentVertex = vertex;
+    jumpTo: function (name) {
+        if (this.graph.hasVertexNamed(name)) {
+            this.currentVertex = this.graph.getVertexNamed(name);
             this._startActions();
             return true;
         }
         return false;
     },
 
-    next: function () {
-        var vertex = this.graph.getNextVertex(this.currentVertex);
+    next: function (options) {
+        var vertex = this.graph.getNextVertex(this.currentVertex, options);
         if (vertex) {
             this.currentVertex = vertex;
             this._startActions();

--- a/lib/graph.js
+++ b/lib/graph.js
@@ -5,9 +5,22 @@ var extend = require('./extend');
 var GraphValidator = require('./graph_validator');
 
 var Graph = function (vertices, edges, source) {
-    this.vertices = vertices || {};
-    this.edges = edges || {};
+    this.vertices = vertices || [];
+    this.edges = edges || [];
     this.source = source;
+
+    this.vertexMap = this.vertices.reduce(function (previous, vertex) {
+        previous[vertex.getName()] = vertex;
+        return previous;
+    }, {});
+
+    this.edgeMap = this.edges.reduce(function (previous, edge) {
+        if (!previous[edge.getEdgeSource()]) {
+            previous[edge.getEdgeSource()] = [];
+        }
+        previous[edge.getEdgeSource()].push(edge);
+        return previous;
+    }, {});
 };
 Graph.extend =  _.partial(extend, Graph);
 
@@ -17,43 +30,58 @@ _.extend(Graph.prototype, {
     },
 
     getAllEdgeTargets: function () {
-        var edgeSources = _.keys(this.getAllEdges());
-        var edgeDestinations = _.values(this.getAllEdges());
-        return _.union(edgeSources, edgeDestinations);
+        var edgeTargets = this.getAllEdges().reduce(function (previous, edge) {
+            previous.push(edge.getEdgeSource());
+            previous.push(edge.getEdgeSink());
+            return previous;
+        }, []);
+        return _.uniq(edgeTargets);
     },
 
     getAllSinkNames: function () {
-        var edgeSources = _.keys(this.getAllEdges());
+        var edgeSources = _.keys(this.edgeMap);
         return _.difference(this.getAllVertexNames(), edgeSources);
     },
 
     getAllTargets: function () {
-        var sourceVertices = [ this.getSourceVertex() ];
-        return _.union(this.getAllEdgeTargets(), sourceVertices);
+        var sources = [ this.getSourceName() ];
+        return _.union(this.getAllEdgeTargets(), sources);
     },
 
     getAllVertexNames: function () {
-        return _.keys(this.getAllVertices());
+        return _.keys(this.vertexMap);
     },
 
     getAllVertices: function () {
         return this.vertices;
     },
 
-    getNextVertex: function (vertex) {
-        return this.edges[vertex];
+    getNextVertex: function (vertex, options) {
+        var edges = this.edgeMap[vertex.getName()];
+        if (!edges) {
+            return;
+        }
+        var nextEdgeIdx = _.findIndex(edges, function (edge) {
+            return edge.shouldTakeEdge(options);
+        });
+        var nextEdge = edges[nextEdgeIdx];
+        return this.vertexMap[nextEdge.getEdgeSink()];
     },
 
-    getSourceVertex: function () {
+    getSourceName: function () {
         return this.source;
     },
 
-    getVertexPayload: function (vertex) {
-        return this.vertices[vertex];
+    getSourceVertex: function () {
+        return this.getVertexNamed(this.source);
     },
 
-    hasVertex: function (vertex) {
-        return _.has(this.getAllVertices(), vertex);
+    getVertexNamed: function (name) {
+        return this.vertexMap[name];
+    },
+
+    hasVertexNamed: function (name) {
+        return _.has(this.vertexMap, name);
     },
 
     validate: function () {

--- a/lib/graph_composer.js
+++ b/lib/graph_composer.js
@@ -3,6 +3,7 @@
 var _ = require('underscore');
 var assertWith = require('./assert_with');
 var extend = require('./extend');
+var Edge = require('./edge');
 var Graph = require('./graph');
 
 var GraphComposer = function (graph1, graph2) {
@@ -17,7 +18,7 @@ GraphComposer.extend = _.partial(extend, GraphComposer);
 _.extend(GraphComposer.prototype, {
     compose: function ()  {
         this.checkForAmbiguities();
-        var source = this.getFirstGraph().getSourceVertex();
+        var source = this.getFirstGraph().getSourceName();
         var vertices = this.combineAllVertices();
         var edges = this.combineAllEdges();
         return new Graph(vertices, edges, source);
@@ -25,11 +26,11 @@ _.extend(GraphComposer.prototype, {
 
     bridgeSinksToSource: function () {
         var firstGraphSinks = this.getFirstGraph().getAllSinkNames();
-        var secondGraphSource = this.getSecondGraph().getSourceVertex();
+        var secondGraphSource = this.getSecondGraph().getSourceName();
         return firstGraphSinks.reduce(function (bridgeEdges, sinkName) {
-            bridgeEdges[sinkName] = secondGraphSource;
+            bridgeEdges.push(new Edge(sinkName, secondGraphSource));
             return bridgeEdges;
-        }, {});
+        }, []);
     },
 
     checkForAmbiguities: function () {
@@ -44,14 +45,16 @@ _.extend(GraphComposer.prototype, {
     combineAllVertices: function () {
         var ourVertices = this.getFirstGraph().getAllVertices();
         var theirVertices = this.getSecondGraph().getAllVertices();
-        return _.extend({}, ourVertices, theirVertices);
+        var union = _.union(ourVertices, theirVertices);
+        return _.uniq(union);
     },
 
     combineAllEdges: function () {
         var ourEdges = this.getFirstGraph().getAllEdges();
         var theirEdges = this.getSecondGraph().getAllEdges();
         var bridgeEdges = this.bridgeSinksToSource();
-        return _.extend({}, ourEdges, theirEdges, bridgeEdges);
+        var union = _.union(ourEdges, theirEdges, bridgeEdges);
+        return _.uniq(union);
     },
 
     getFirstGraph: function () {

--- a/lib/graph_validator.js
+++ b/lib/graph_validator.js
@@ -45,12 +45,12 @@ _.extend(GraphValidator.prototype, {
     },
 
     validateSourceVertexExists: function () {
-        if (!this.graph.getSourceVertex()) {
+        if (!this.graph.getSourceName()) {
             throw new Error('Source is not defined');
         }
 
         var vertices = this.graph.getAllVertexNames();
-        var source = this.graph.getSourceVertex();
+        var source = this.graph.getSourceName();
         if (missingValue(vertices, source)) {
             throw new Error('Source "' + source + '" is an unknown vertex');
         }

--- a/lib/vertex.js
+++ b/lib/vertex.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var _ = require('underscore');
+var extend = require('./extend');
+
+var Vertex = function (name, payload) {
+    this.name = name;
+    this.payload = payload;
+};
+Vertex.extend = _.partial(extend, Vertex);
+
+_.extend(Vertex.prototype, {
+    getName: function () {
+        return this.name;
+    },
+
+    getPayload: function () {
+        return this.payload;
+    },
+});
+
+module.exports = Vertex;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An action-driven traverser of directed graphs",
   "main": "flow.js",
   "scripts": {

--- a/tests/_bundle.spec.js
+++ b/tests/_bundle.spec.js
@@ -6,10 +6,12 @@ describe('flow', function () {
     [
         'Action',
         'Builder',
+        'Edge',
         'Graph',
         'GraphComposer',
         'GraphValidator',
         'Traverser',
+        'Vertex',
     ].forEach(function (namespace) {
         it('should have an extensible namespaced constructor', function () {
             expect(Flow[namespace]).toBeDefined();

--- a/tests/builder.spec.js
+++ b/tests/builder.spec.js
@@ -1,6 +1,9 @@
 'use strict';
 
 var Builder = require('../lib/builder');
+var helpers = require('./helpers');
+
+var expectEdgesMatch = helpers.expectEdgesMatch;
 
 describe('builder', function () {
     var actionBuilderFn;
@@ -15,9 +18,18 @@ describe('builder', function () {
 
     describe('when building with vertices', function () {
         beforeEach(function () {
-            flow = builder.addVertex('v1', 'v1:payload', 'v2')
-                .addVertex('v2', 'v2:payload', 'v3')
-                .addVertex('v3', 'v3:payload')
+            flow = builder
+                .addVertex({
+                    name: 'v1',
+                    next: 'v2'
+                }, 'v1: payload')
+                .addVertex({
+                    name: 'v2',
+                    next: 'v3',
+                }, 'v2:payload')
+                .addVertex({
+                    name: 'v3',
+                }, 'v3:payload')
                 .startAtVertex('v1')
                 .addActionBuilder(actionBuilderFn)
                 .addActionBuilder(actionBuilderFn)  // Yes, we're testing adding multiples :)
@@ -29,11 +41,62 @@ describe('builder', function () {
         it('should create a graph matching definition', function () {
             var graph = flow.getGraph();
             expect(graph.getAllVertexNames()).toEqual(['v1', 'v2', 'v3']);
-            expect(graph.getAllEdges()).toEqual({
+            expectEdgesMatch(graph, {
                 'v1': 'v2',
                 'v2': 'v3',
             });
-            expect(graph.getSourceVertex()).toEqual('v1');
+            expect(graph.getSourceName()).toEqual('v1');
+        });
+
+        it('should inject action builders and finished functions', function () {
+            expect(flow.getActionBuilderFunctions()).toEqual([
+                actionBuilderFn,
+                actionBuilderFn,
+            ]);
+            expect(flow.getWhenFinishedFunctions()).toEqual([
+                whenFinishedFn,
+                whenFinishedFn,
+            ]);
+        });
+    });
+
+    describe('when building with multi-edge vertices', function () {
+        beforeEach(function () {
+            flow = builder
+                .addVertex({
+                    name: 'v1',
+                    next: {
+                        v2: function (options) {
+                            return options.path === 'v2';
+                        },
+                        v3: function (options) {
+                            return options.path === 'v3';
+                        },
+                    },
+                }, 'v1: payload')
+                .addVertex({
+                    name: 'v2',
+                    next: 'v3',
+                }, 'v2:payload')
+                .addVertex({
+                    name: 'v3',
+                }, 'v3:payload')
+                .startAtVertex('v1')
+                .addActionBuilder(actionBuilderFn)
+                .addActionBuilder(actionBuilderFn)  // Yes, we're testing adding multiples :)
+                .whenFinished(whenFinishedFn)
+                .whenFinished(whenFinishedFn)   // Same as above here
+                .build();
+        });
+
+        it('should create a graph matching definition', function () {
+            var graph = flow.getGraph();
+            expect(graph.getAllVertexNames()).toEqual(['v1', 'v2', 'v3']);
+            expectEdgesMatch(graph, {
+                'v1': [ 'v2', 'v3' ],
+                'v2': 'v3',
+            });
+            expect(graph.getSourceName()).toEqual('v1');
         });
 
         it('should inject action builders and finished functions', function () {

--- a/tests/edge.spec.js
+++ b/tests/edge.spec.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var Edge = require('../lib/edge');
+
+describe('edge', function () {
+    var edge;
+    var edgeSource;
+    var edgeSink;
+    var pathChoiceFn;
+
+    beforeEach(function () {
+        edgeSource = 'v1';
+        edgeSink = 'v2';
+        pathChoiceFn = function (options) {
+            return options.choose;
+        };
+    });
+
+    var assertCommonBehavior = function () {
+        it('should return edgeSource when calling getEdgeSource', function () {
+            expect(edge.getEdgeSource()).toEqual(edgeSource);
+        });
+
+        it('should return edgeSink when calling getEdgeSink', function () {
+            expect(edge.getEdgeSink()).toEqual(edgeSink);
+        });
+    };
+
+    describe('when constructing with no pathChoiceFn', function () {
+        beforeEach(function () {
+            edge = new Edge(edgeSource, edgeSink);
+        });
+
+        assertCommonBehavior();
+
+        it('should return true when calling shouldTakeEdge', function () {
+            expect(edge.shouldTakeEdge()).toEqual(true);
+        });
+    });
+
+    describe('when constructing with a pathChoiceFn', function () {
+        beforeEach(function () {
+            edge = new Edge(edgeSource, edgeSink, pathChoiceFn);
+        });
+
+        assertCommonBehavior();
+
+        it('should return false when calling shouldTakeEdge with false-inducing options', function () {
+            var result = edge.shouldTakeEdge({ choose: false });
+            expect(result).toEqual(false);
+        });
+
+        it('should return true when calling shouldTakeEdge with true-inducing options', function () {
+            var result = edge.shouldTakeEdge({ choose: true });
+            expect(result).toEqual(true);
+        });
+    });
+});

--- a/tests/graph.spec.js
+++ b/tests/graph.spec.js
@@ -1,6 +1,10 @@
 'use strict';
 
 var Graph = require('../lib/graph');
+var helpers = require('./helpers');
+
+var edgeData = helpers.edgeData;
+var vertexData = helpers.vertexData;
 
 describe('graph', function () {
     var edges;
@@ -8,17 +12,13 @@ describe('graph', function () {
     var source;
     var vertices;
 
-    var vertexData = function (name) {
-        return { name: name };
-    };
-
     describe('when constructing a graph with no arguments', function () {
         beforeEach(function () {
             graph = new Graph();
         });
 
         it('should default edges property to an empty object', function () {
-            expect(graph.getAllEdges()).toEqual({});
+            expect(graph.getAllEdges()).toEqual([]);
         });
 
         it('shoudl default vertices propery to an empty object', function () {
@@ -35,9 +35,9 @@ describe('graph', function () {
 
     describe('when constructing a single-vertex graph with integrity', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData('v1'),
-            };
+            vertices = [
+                vertexData('v1'),
+            ];
             source = 'v1';
             graph = new Graph(vertices, edges, source);
         });
@@ -60,14 +60,14 @@ describe('graph', function () {
 
     describe('when constructing a multi-vertex graph without integrity', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData('v1'),
-                'v2': vertexData('v2'),
-            };
-            edges = {
-                'v1': 'v2',
-                'v2': 'v3', // Invalid Integrity - no v3 vertex
-            };
+            vertices = [
+                vertexData('v1'),
+                vertexData('v2'),
+            ];
+            edges = [
+                edgeData('v1', 'v2'),
+                edgeData('v2', 'v3'), // Invalid Integrity - no v3 vertex
+            ];
             source = 'v1';
             graph = new Graph(vertices, edges, source);
         });
@@ -98,42 +98,42 @@ describe('graph', function () {
 
         describe('when calling getNextVertex', function () {
             it('should return the next vertex described by the edges', function () {
-                expect(graph.getNextVertex('v2')).toEqual('v3');
+                expect(graph.getNextVertex(vertices[0])).toEqual(vertices[1]);
+            });
+        });
+
+        describe('when calling getSourceName', function () {
+            it('should return the source property', function () {
+                expect(graph.getSourceName()).toEqual(source);
             });
         });
 
         describe('when calling getSourceVertex', function () {
-            it('should return the source property', function () {
-                expect(graph.getSourceVertex()).toEqual(source);
+            it('should return the vertex whose name matches the source property', function () {
+                expect(graph.getSourceVertex()).toEqual(vertices[0]);
             });
         });
 
-        describe('when calling getVertexPayload',function () {
-            it('should return the payload for the given vertex', function () {
-                expect(graph.getVertexPayload('v1')).toEqual(vertexData('v1'));
-            });
-        });
-
-        describe('when calling hasVertex', function () {
+        describe('when calling hasVertexNamed', function () {
             it('should return false for a nonexistent vertex', function () {
-                expect(graph.hasVertex('nonexistent')).toEqual(false);
+                expect(graph.hasVertexNamed('nonexistent')).toEqual(false);
             });
 
             it('should return true for a known vertex', function () {
-                expect(graph.hasVertex('v2')).toEqual(true);
+                expect(graph.hasVertexNamed('v2')).toEqual(true);
             });
         });
     });
 
     describe('when constructing a multi-vertex graph with integrity', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData('v1'),
-                'v2': vertexData('v2'),
-            };
-            edges = {
-                'v1': 'v2',
-            };
+            vertices = [
+                vertexData('v1'),
+                vertexData('v2'),
+            ];
+            edges = [
+                edgeData('v1', 'v2'),
+            ];
             source = 'v1';
             graph = new Graph(vertices, edges, source);
         });
@@ -141,6 +141,44 @@ describe('graph', function () {
         describe('when calling getAllSinkNames', function () {
             it('should return an array containing sinks -vertices that have no next target', function () {
                 expect(graph.getAllSinkNames()).toEqual([ 'v2' ]);
+            });
+        });
+
+        describe('when calling validate', function () {
+            it('should not throw error', function () {
+                var validate = function () {
+                    graph.validate();
+                };
+                expect(validate).not.toThrowError();
+            });
+        });
+    });
+
+    describe('when constructing a muli-vertex multi-edge graph with integrity', function () {
+        beforeEach(function () {
+            vertices = [
+                vertexData('v1'),
+                vertexData('v2'),
+                vertexData('v3'),
+                vertexData('v4'),
+            ];
+            edges = [
+                edgeData('v1', 'v2', function () {
+                    return false;
+                }),
+                edgeData('v1', 'v3', function () {
+                    return true;
+                }),
+                edgeData('v2', 'v4'),
+                edgeData('v3', 'v4'),
+            ];
+            source = 'v1';
+            graph = new Graph(vertices, edges, source);
+        });
+
+        describe('when calling getAllSinkNames', function () {
+            it('should return an array containing sinks -vertices that have no next target', function () {
+                expect(graph.getAllSinkNames()).toEqual([ 'v4' ]);
             });
         });
 

--- a/tests/graph_composer.spec.js
+++ b/tests/graph_composer.spec.js
@@ -2,6 +2,10 @@
 
 var Graph = require('../lib/graph');
 var GraphComposer = require('../lib/graph_composer');
+var helpers = require('./helpers');
+
+var edgeData = helpers.edgeData;
+var vertexData = helpers.vertexData;
 
 describe('graph_composer', function () {
     var composer;
@@ -35,23 +39,23 @@ describe('graph_composer', function () {
     describe('when composing with graphs with ambiguous vertices', function () {
         beforeEach(function () {
             graph1 = createGraph({
-                vertices: {
-                    'v1': 'payload',
-                    'v2': 'payload'
-                },
-                edges: {
-                    'v1': 'v2',
-                },
+                vertices: [
+                    vertexData('v1'),
+                    vertexData('v2'),
+                ],
+                edges: [
+                    edgeData('v1', 'v2'),
+                ],
                 source: 'v1'
             });
             graph2 = createGraph({
-                vertices: {
-                    'v1': 'payload',
-                    'v2': 'payload'
-                },
-                edges: {
-                    'v1': 'v2',
-                },
+                vertices: [
+                    vertexData('v1'),
+                    vertexData('v2'),
+                ],
+                edges: [
+                    edgeData('v1', 'v2'),
+                ],
                 source: 'v1'
             });
             composer = new GraphComposer(graph1, graph2);
@@ -68,13 +72,17 @@ describe('graph_composer', function () {
     describe('when composing with two unambiguous single-vertex graphs', function () {
         beforeEach(function () {
             graph1 = createGraph({
-                vertices: { 'v1': 'payload' },
-                edges: {},
+                vertices: [
+                    vertexData('v1'),
+                ],
+                edges: [],
                 source: 'v1',
             });
             graph2 = createGraph({
-                vertices: { 'v2': 'payload' },
-                edges: {},
+                vertices: [
+                    vertexData('v2'),
+                ],
+                edges: [],
                 source: 'v2',
             });
             composer = new GraphComposer(graph1, graph2);
@@ -83,8 +91,8 @@ describe('graph_composer', function () {
         it('should create a graph starting at v1 and ending at v2', function () {
             resultGraph = composer.compose();
             expect(resultGraph.getAllVertexNames()).toEqual(['v1', 'v2']);
-            expect(resultGraph.getAllEdges()).toEqual({ 'v1': 'v2' });
-            expect(resultGraph.getSourceVertex()).toEqual('v1');
+            expect(resultGraph.getAllEdges().length).toEqual(1);
+            expect(resultGraph.getSourceName()).toEqual('v1');
             expect(resultGraph.getAllSinkNames()).toEqual([ 'v2' ]);
         });
     });
@@ -92,19 +100,23 @@ describe('graph_composer', function () {
     describe('when composing with two unambiguous multi-vertex graphs', function () {
         beforeEach(function () {
             graph1 = createGraph({
-                vertices: {
-                    'v1': 'payload',
-                    'v2': 'payload',
-                },
-                edges: { 'v1': 'v2' },
+                vertices: [
+                    vertexData('v1'),
+                    vertexData('v2'),
+                ],
+                edges: [
+                    edgeData('v1', 'v2'),
+                ],
                 source: 'v1',
             });
             graph2 = createGraph({
-                vertices: {
-                    'v3': 'payload',
-                    'v4': 'payload',
-                },
-                edges: { 'v3': 'v4' },
+                vertices: [
+                    vertexData('v3'),
+                    vertexData('v4'),
+                ],
+                edges: [
+                    edgeData('v3', 'v4'),
+                ],
                 source: 'v3',
             });
             composer = new GraphComposer(graph1, graph2);
@@ -113,12 +125,8 @@ describe('graph_composer', function () {
         it('should create a graph starting at v1 and ending at v4', function () {
             resultGraph = composer.compose();
             expect(resultGraph.getAllVertexNames()).toEqual(['v1', 'v2', 'v3', 'v4']);
-            expect(resultGraph.getAllEdges()).toEqual({
-                'v1': 'v2',
-                'v2': 'v3',
-                'v3': 'v4',
-            });
-            expect(resultGraph.getSourceVertex()).toEqual('v1');
+            expect(resultGraph.getAllEdges().length).toEqual(3);
+            expect(resultGraph.getSourceName()).toEqual('v1');
             expect(resultGraph.getAllSinkNames()).toEqual([ 'v4' ]);
         });
     });

--- a/tests/graph_validator.spec.js
+++ b/tests/graph_validator.spec.js
@@ -2,10 +2,10 @@
 
 var Graph = require('../lib/graph');
 var GraphValidator = require('../lib/graph_validator');
+var helpers = require('./helpers');
 
-function vertexData() {
-    return {};
-}
+var edgeData = helpers.edgeData;
+var vertexData = helpers.vertexData;
 
 describe('graph_validator', function () {
     var edges;
@@ -38,9 +38,9 @@ describe('graph_validator', function () {
 
     describe('when validating a graph with no source', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData(),
-            };
+            vertices = [
+                vertexData('v1'),
+            ];
             source = undefined;
             graph = new Graph(vertices, edges, source);
             validator = new GraphValidator(graph);
@@ -50,9 +50,9 @@ describe('graph_validator', function () {
 
     describe('when validating a single-vertex graph', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData(),
-            };
+            vertices = [
+                vertexData('v1'),
+            ];
             source = 'v1';
             graph = new Graph(vertices, edges, source);
             validator = new GraphValidator(graph);
@@ -62,9 +62,9 @@ describe('graph_validator', function () {
 
     describe('when validating a single-vertex graph with mismatched source', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData(),
-            };
+            vertices = [
+                vertexData('v1'),
+            ];
             source = 'not_a_real_source';
             graph = new Graph(vertices, edges, source);
             validator = new GraphValidator(graph);
@@ -74,13 +74,13 @@ describe('graph_validator', function () {
 
     describe('when validating a 2-vertex graph', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData(),
-                'v2': vertexData(),
-            };
-            edges = {
-                'v1': 'v2'
-            };
+            vertices = [
+                vertexData('v1'),
+                vertexData('v2'),
+            ];
+            edges = [
+                edgeData('v1', 'v2'),
+            ];
             source = 'v1';
             graph = new Graph(vertices, edges, source);
             validator = new GraphValidator(graph);
@@ -90,11 +90,11 @@ describe('graph_validator', function () {
 
     describe('when validating a 2-vertex graph with an orphaned vertex', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData(),
-                'v2': vertexData(),
-            };
-            edges = {};
+            vertices = [
+                vertexData('v1'),
+                vertexData('v2'),
+            ];
+            edges = [];
             source = 'v1';
             graph = new Graph(vertices, edges, source);
             validator = new GraphValidator(graph);
@@ -104,12 +104,12 @@ describe('graph_validator', function () {
 
     describe('when validating a 2-vertex graph with nonexistent edge source', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData(),
-            };
-            edges = {
-                'not_real_edge_source': 'v1'
-            };
+            vertices = [
+                vertexData('v1'),
+            ];
+            edges = [
+                edgeData('not_real_edge_source', 'v1'),
+            ];
             source = 'v1';
             graph = new Graph(vertices, edges, source);
             validator = new GraphValidator(graph);
@@ -119,12 +119,12 @@ describe('graph_validator', function () {
 
     describe('when validating a 2-vertex graph with nonexistent edge sink', function () {
         beforeEach(function () {
-            vertices = {
-                'v1': vertexData(),
-            };
-            edges = {
-                'v1': 'not_real_edge_sink'
-            };
+            vertices = [
+                vertexData('v1'),
+            ];
+            edges = [
+                edgeData('v1', 'not_real_edge_sink'),
+            ];
             source = 'v1';
             graph = new Graph(vertices, edges, source);
             validator = new GraphValidator(graph);

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var _ = require('underscore');
+var Edge = require('../lib/edge');
+var Vertex = require('../lib/vertex');
+
+exports.edgeData = function (edgeSource, edgeSink, pathChoiceFn) {
+    return new Edge(edgeSource, edgeSink, pathChoiceFn);
+};
+
+exports.expectEdgesMatch = function (graph, expectedEdgeMap) {
+    var actualEdgeMap = graph.getAllEdges().reduce(function (previous, edge) {
+        var source = edge.getEdgeSource();
+        if (!previous[source]) {
+            previous[source] = edge.getEdgeSink();
+            return previous;
+        }
+
+        if (_.isString(previous[source])) {
+            previous[source] = [ previous[source] ];
+        }
+        previous[source].push(edge.getEdgeSink());
+        return previous;
+    }, {});
+    expect(actualEdgeMap).toEqual(expectedEdgeMap);
+};
+
+exports.vertexData = function (name, payload) {
+    return new Vertex(name, payload);
+};

--- a/tests/vertex.spec.js
+++ b/tests/vertex.spec.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var Vertex = require('../lib/vertex');
+
+describe('vertex', function () {
+    var name;
+    var payload;
+    var vertex;
+    beforeEach(function () {
+        name = 'v1';
+        payload = { foo: 'bar' };
+        vertex = new Vertex(name, payload);
+    });
+
+    it('should return name when calling getName', function () {
+        expect(vertex.getName()).toEqual(name);
+    });
+
+    it('should return payload when calling getPayload', function () {
+        expect(vertex.getPayload()).toEqual(payload);
+    });
+});


### PR DESCRIPTION
https://trello.com/c/lLrNkded/1-add-support-for-multiple-next-targets

- Adds edges and vertices as first class types

- Modifies graph internals to consume lists edges and vertices, rather than maps of edge- and vertex-like data

- Modifies flow internals to consume new graph api changes

- Modifies builder `addVertex` method signature, combining name and next into an options parameter.

As a result of the modifications to interfaces, this should be considered a compatibility-breaking change.