### PR TITLE
Dev/use persistent actions

### DIFF
--- a/lib/action.js
+++ b/lib/action.js
@@ -1,15 +1,9 @@
 'use strict';
 
 var _ = require('underscore');
-var assertWith = require('./assert_with');
 var extend = require('./extend.js');
 
-var Action = function (options) {
-    assertWith(options)
-        .expectProperty('flow', 'Action requires a flow');
-    this.flow = options.flow;
-    this.payload = options.payload;
-};
+var Action = function () {};
 Action.extend = _.partial(extend, Action);
 
 _.extend(Action.prototype, {
@@ -17,7 +11,11 @@ _.extend(Action.prototype, {
         this.flow.next();
     },
 
-    start: function () {
+    setFlow: function (flow) {
+        this.flow = flow;
+    },
+
+    start: function (/* payload */) {
         // @TODO Override in subclasses
     },
 });

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -13,7 +13,7 @@ var Builder = function () {
     this.edges = [];
     this.source = undefined;
     this.graph = undefined;
-    this.actionBuilderFunctions = [];
+    this.actions = [];
     this.whenFinishedFunctions = [];
 };
 Builder.extend = _.partial(extend, Builder);
@@ -35,8 +35,8 @@ _.extend(Builder.prototype, {
         }, []);
     },
 
-    addActionBuilder: function (actionBuilderFn) {
-        this.actionBuilderFunctions.push(actionBuilderFn);
+    addAction: function (actionBuilderFn) {
+        this.actions.push(actionBuilderFn);
         return this;
     },
 
@@ -52,7 +52,7 @@ _.extend(Builder.prototype, {
         this.graph = new Graph(this.vertices, this.edges, this.source);
         return new Flow({
             graph: this.graph,
-            action_builder_functions: this.actionBuilderFunctions,
+            actions: this.actions,
             when_finished_functions: this.whenFinishedFunctions,
         });
     },

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -8,7 +8,7 @@ var GraphComposer = require('./graph_composer');
 
 var Flow = function (options) {
     assertWith(options).expectProperty('graph', 'Flow requires a graph');
-    this.actionBuilderFunctions = options.action_builder_functions || [];
+    this.actions = options.actions || [];
     this.whenFinishedFunctions = options.when_finished_functions || [];
     this.graph = options.graph;
     this.currentVertex = this.getGraph().getSourceVertex();
@@ -16,19 +16,19 @@ var Flow = function (options) {
 Flow.extend = _.partial(extend, Flow);
 
 _.extend(Flow.prototype, {
-    _buildActions: function (vertex) {
+    _readyActions: function () {
         var flow = this;
-        var payload = vertex.getPayload();
-        return this.actionBuilderFunctions.map(function (actionBuilderFn) {
-            return actionBuilderFn(flow, payload);
+        return this.actions.map(function (action) {
+            action.setFlow(flow);
+            return action;
         });
     },
 
     _startActions: function () {
-        var actions = this._buildActions(this.getCurrent());
+        var actions = this._readyActions(this.getCurrent());
         actions.forEach(function (action) {
-            action.start();
-        });
+            action.start(this.currentVertex.getPayload());
+        }.bind(this));
     },
 
     _triggerWhenFinished: function () {
@@ -42,23 +42,23 @@ _.extend(Flow.prototype, {
             this.getGraph(),
             otherFlow.getGraph()
         ).compose();
-        var actionBuilderFunctions = [].concat(
-            this.getActionBuilderFunctions(),
-            otherFlow.getActionBuilderFunctions()
+        var actions = [].concat(
+            this.getActions(),
+            otherFlow.getActions()
         );
         var whenFinishedFunctions = [].concat(
             this.getWhenFinishedFunctions(),
             otherFlow.getWhenFinishedFunctions()
         );
         return new Flow({
-            action_builder_functions: actionBuilderFunctions,
+            actions: actions,
             when_finished_functions: whenFinishedFunctions,
             graph: composedGraph,
         });
     },
 
-    getActionBuilderFunctions: function () {
-        return this.actionBuilderFunctions;
+    getActions: function () {
+        return this.actions;
     },
 
     getCurrent: function () {

--- a/tests/action.spec.js
+++ b/tests/action.spec.js
@@ -3,7 +3,7 @@
 var Action = require('../lib/action');
 
 describe('action', function () {
-    var adapter;
+    var action;
     var flow;
     var payload;
 
@@ -12,26 +12,24 @@ describe('action', function () {
             next: jasmine.createSpy(),
         };
         payload = {};
-        adapter = new Action({
-            flow: flow,
-            payload: payload,
-        });
+        action = new Action();
+        action.setFlow(flow);
     });
 
     it('should exist', function () {
-        expect(adapter).toBeDefined();
+        expect(action).toBeDefined();
     });
 
     describe('when calling next', function () {
         it('should call next on the passed flow', function () {
-            adapter.next();
+            action.next();
             expect(flow.next).toHaveBeenCalled();
         });
     });
 
     describe('when calling start', function () {
         it('should throw no error', function () {
-            adapter.start();
+            action.start(payload);
         });
     });
 });

--- a/tests/builder.spec.js
+++ b/tests/builder.spec.js
@@ -1,18 +1,17 @@
 'use strict';
 
+var Action = require('../lib/action');
 var Builder = require('../lib/builder');
 var helpers = require('./helpers');
 
 var expectEdgesMatch = helpers.expectEdgesMatch;
 
 describe('builder', function () {
-    var actionBuilderFn;
     var builder;
     var flow;
     var whenFinishedFn;
     beforeEach(function () {
         builder = new Builder();
-        actionBuilderFn = jasmine.createSpy();
         whenFinishedFn = jasmine.createSpy();
     });
 
@@ -31,8 +30,8 @@ describe('builder', function () {
                     name: 'v3',
                 }, 'v3:payload')
                 .startAtVertex('v1')
-                .addActionBuilder(actionBuilderFn)
-                .addActionBuilder(actionBuilderFn)  // Yes, we're testing adding multiples :)
+                .addAction(new Action())
+                .addAction(new Action())  // Yes, we're testing adding multiples :)
                 .whenFinished(whenFinishedFn)
                 .whenFinished(whenFinishedFn)   // Same as above here
                 .build();
@@ -48,11 +47,11 @@ describe('builder', function () {
             expect(graph.getSourceName()).toEqual('v1');
         });
 
-        it('should inject action builders and finished functions', function () {
-            expect(flow.getActionBuilderFunctions()).toEqual([
-                actionBuilderFn,
-                actionBuilderFn,
-            ]);
+        it('should inject actions and finished functions', function () {
+            expect(flow.getActions().length).toEqual(2);
+            flow.getActions().forEach(function (action) {
+                expect(action instanceof Action).toEqual(true);
+            });
             expect(flow.getWhenFinishedFunctions()).toEqual([
                 whenFinishedFn,
                 whenFinishedFn,
@@ -82,8 +81,8 @@ describe('builder', function () {
                     name: 'v3',
                 }, 'v3:payload')
                 .startAtVertex('v1')
-                .addActionBuilder(actionBuilderFn)
-                .addActionBuilder(actionBuilderFn)  // Yes, we're testing adding multiples :)
+                .addAction(new Action())
+                .addAction(new Action())  // Yes, we're testing adding multiples :)
                 .whenFinished(whenFinishedFn)
                 .whenFinished(whenFinishedFn)   // Same as above here
                 .build();
@@ -99,11 +98,11 @@ describe('builder', function () {
             expect(graph.getSourceName()).toEqual('v1');
         });
 
-        it('should inject action builders and finished functions', function () {
-            expect(flow.getActionBuilderFunctions()).toEqual([
-                actionBuilderFn,
-                actionBuilderFn,
-            ]);
+        it('should inject actions and finished functions', function () {
+            expect(flow.getActions().length).toEqual(2);
+            flow.getActions().forEach(function (action) {
+                expect(action instanceof Action).toEqual(true);
+            });
             expect(flow.getWhenFinishedFunctions()).toEqual([
                 whenFinishedFn,
                 whenFinishedFn,

--- a/tests/flow.spec.js
+++ b/tests/flow.spec.js
@@ -18,19 +18,12 @@ function defineTestFlowAction() {
 
 describe('flow', function () {
     var Action;
-    var adapterBuilderFn;
     var finishedFn;
     var flow;
     var graph;
 
     beforeEach(function () {
         Action = defineTestFlowAction();
-        adapterBuilderFn = function (flow, payload) {
-            return new Action({
-                flow: flow,
-                payload: payload,
-            });
-        };
         finishedFn = jasmine.createSpy();
     });
 
@@ -42,20 +35,19 @@ describe('flow', function () {
                     [],
                     'v1'
                 ),
-                action_builder_functions: undefined,
+                actions: undefined,
                 when_finished_functions: undefined,
             });
-            expect(flow.getActionBuilderFunctions()).toEqual([]);
+            expect(flow.getActions()).toEqual([]);
             expect(flow.getWhenFinishedFunctions()).toEqual([]);
         });
     });
 
     var assertStartsAdapterWith = function (payload) {
         it('should call start on an adapter with the next vertex payload', function () {
-            var callingContext;
             var calls = Action.prototype.start.calls;
-            callingContext = calls.mostRecent().object;
-            expect(callingContext.payload).toEqual(payload);
+            var actualPayload = calls.mostRecent().args[0];
+            expect(actualPayload).toEqual(payload);
         });
     };
 
@@ -75,7 +67,7 @@ describe('flow', function () {
             );
             flow = new Flow({
                 graph: graph,
-                action_builder_functions: [ adapterBuilderFn ],
+                actions: [ new Action() ],
                 when_finished_functions: [ finishedFn ],
             });
         });
@@ -98,7 +90,7 @@ describe('flow', function () {
                     );
                     otherFlow = new Flow({
                         graph: otherGraph,
-                        action_builder_functions: [ adapterBuilderFn ],
+                        actions: [ new Action() ],
                         when_finished_functions: [ finishedFn ],
                     });
                     resultFlow = flow.compose(otherFlow);
@@ -214,7 +206,7 @@ describe('flow', function () {
             );
             flow = new Flow({
                 graph: graph,
-                action_builder_functions: [ adapterBuilderFn ],
+                actions: [ new Action() ],
                 when_finished_functions: [ finishedFn ],
             });
         });


### PR DESCRIPTION
Currently, actions are attached to flows via `actionBuilder` functions. Each jump will create a new action.

However, there are times when we want a single instance of an action to persist through the life of a flow, specifically when we want to track or act on the results of multiple jumps.