### PR TITLE
Dev/npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,13 @@
 .git/
 coverage/
+docs/
 dist/.keep
 node_modules/
 tests/
+.coveralls.yml
+.eslintignore
 .eslintrc.json
 .gitignore
+.travis.yml
 webpack.config.js
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,25 @@
 language: node_js
 node_js: 6.9.2
-
 cache: yarn
-
 before_install:
-  # Repo for newer Node.js versions
-  - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-  # Repo for Yarn
-  - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
-
+- curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+- curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+- echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+- sudo apt-get update -qq
+- sudo apt-get install -y -qq yarn
 install:
-  - yarn
-
+- yarn
 script:
-  - yarn build
-  - yarn lint
-  - yarn test
-
+- yarn build
+- yarn lint
+- yarn test
 after_success:
-  - yarn report-coverage
-
+- yarn report-coverage
 notifications:
   email: false
+deploy:
+  on:
+    tags: true
+  provider: npm
+  api_key:
+    secure: sD0Y6Oy2L5IuzZf6c4cAFVbXP682nlF1gaPH7GvObULNWeXo74bppY6RhQOsQIrxS2f9GRANXwJxi50x1K2SI4pl5En/EwDtZIOvwyY3o4s1K+g2B1S5sLJYKBC8syUelOR5j4XlSUvCf+updWY0hiRMIasHrnunsrafUQlkHVWyW2PJ5TcSlFtGcmQiaChnfzOTpFMXKLP5vjVnS00gn2uaKpk3WuLpPsD9COh4YMwL+ZXuUEslbKhTwpI5EY9mZ1+0nVU6qY/HtSQrE2tt5Lrk/pOtSbSeUBHRZyLwP5iOm2QdPgYtx0W65v2hNUr0psPfUdTMKDGjZcLNiYBti0iZT2kLWGFmJ6UYemF7vyc6MW58iytteAg/Mc4p1ciXdM8SYoWoBy/YE1wrypoT4FqSGywL5az4iMi5C6PTyOqcV05sQEXfbEKxhyT7g5Z/KJQCZGnIjPH9WR3hYcLCdgovPxQQz+kh4CwY22V0Sut3KDMQXEeeqmtGO4I7pc0tnwioKew9vkeQr39Jc+tgbeEAJxerU0D1nZjMcnvOMl+b46WrYDMMQBVwBPWkd0VMVoxn1GPtzTVrBzwaOBEb9Vk6K0sx2Gza6L2lFO+HfmTLZpiWKSmd5f/jM8SXZrpLy93hK7uuBIZVUayBIOafAbIDH862vo0AQvK9//qkQHM=

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "flow",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "An action-driven traverser of directed graphs",
-  "main": "flow.js",
+  "main": "dist/flow.js",
   "scripts": {
     "build": "node_modules/.bin/webpack",
     "lint": "./node_modules/.bin/eslint -c .eslintrc.json .",


### PR DESCRIPTION
Bumps flows up to v1.0, sets up an autopublish rule for Travis to push to NPM on tagged builds.